### PR TITLE
Add GitHub Skills Activity - Resolves Issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing "GitHub Skills" activity to resolve issue #6.

## Changes Made
- ✅ Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- ✅ Included proper description mentioning GitHub Certifications program
- ✅ Set schedule: Mondays and Thursdays, 3:00 PM - 4:30 PM
- ✅ Maximum 25 participants
- ✅ Ready for student registrations

## Issue Addressed
Fixes #6 - 🚨 Missing Activity: GitHub Skills

This was time-sensitive as mentioned in the issue - students needed to register by the end of the week for the GitHub Certifications program that helps with college applications.

## Testing
The activity now appears in the activities list and students can sign up for it through the existing signup system.